### PR TITLE
clisBNB delegation implementation

### DIFF
--- a/contracts/ceros/interfaces/IHelioProviderV2.sol
+++ b/contracts/ceros/interfaces/IHelioProviderV2.sol
@@ -3,6 +3,14 @@ pragma solidity ^0.8.0;
 
 interface IHelioProviderV2 {
     /**
+     * Structs
+     */
+    struct Delegation {
+        address delegateTo; // who helps delegator to hold clisBNB, aka the delegatee
+        uint256 amount;
+    }
+
+    /**
      * Events
      */
 
@@ -35,12 +43,18 @@ interface IHelioProviderV2 {
     event ChangeBNBStakingPool(address pool);
 
     event ChangeLiquidationStrategy(address strategy);
+
+    event ChangeDelegateTo(address account, address oldDelegatee, address newDelegatee);
+    event ChangeGuardian(address oldGuardian, address newGuardian);
+
     /**
      * Deposit
      */
 
     // in BNB
     function provide() external payable returns (uint256);
+    function provide(address _delegateTo) external payable returns (uint256);
+    function changeDelegatee(address _delegateTo) external;
 
     // in aBNBc
     // function provideInABNBc(uint256 amount) external returns (uint256);


### PR DESCRIPTION
When user collateralize their BNB, same amount of clisBNB token will mint to the user. we made some changes to the provider contract, so that the user can decide someone to whole all or partial of the clisBNB, a single can delegate to only one delegatee, while he has the right to change the delegatee anytime.

1. added an overload method `provide(address _delegateTo)`
2. added `changeDelegatee(address _newDelegateTo)`

changed the burn mechanism of clisBNB, will burn delegatee's clisBNB first then delegator's.