### PR TITLE
Revoke role from old interaction contract

### DIFF
--- a/contracts/amo/DynamicDutyCalculator.sol
+++ b/contracts/amo/DynamicDutyCalculator.sol
@@ -227,6 +227,7 @@ contract DynamicDutyCalculator is IDynamicDutyCalculator, Initializable, AccessC
 
         if (what == "interaction") {
             require(interaction != _addr, "AggMonetaryPolicy/interaction-already-set");
+            revokeRole(INTERACTION, interaction);
             interaction = _addr;
             grantRole(INTERACTION, _addr);
         } else if (what == "lisUSD") {

--- a/test/foundry/DynamicDutyCalculator.t.sol
+++ b/test/foundry/DynamicDutyCalculator.t.sol
@@ -682,6 +682,7 @@ contract DynamicDutyCalculatorTest is Test {
 
         (address _interaction, address _lisUSD, address _oracle) = dynamicDutyCalculator.getContracts();
         assertEq(_interaction, address(0xAA));
+        assertEq(dynamicDutyCalculator.hasRole(dynamicDutyCalculator.INTERACTION(), address(interaction)), false);
         assertEq(dynamicDutyCalculator.hasRole(dynamicDutyCalculator.INTERACTION(), _interaction), true);
         assertEq(_lisUSD, address(0xBB));
         assertEq(_oracle, address(0xCC));


### PR DESCRIPTION
When interaction contract address get updated, the role should be revoked from old address to prevent states being updated by it