### PR TITLE
BNB Oracle: query price from resilientOracle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 DEPLOYER_PRIVATE_KEY=
 BSC_API_KEY=
+BSC_TESTNET_RPC=https://data-seed-prebsc-2-s3.binance.org:8545/
+BSC_RPC=https://bsc-dataseed.binance.org/

--- a/contracts/oracle/BnbOracle.sol
+++ b/contracts/oracle/BnbOracle.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
-import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { IResilientOracle } from "./interfaces/IResilientOracle.sol";
+import "./interfaces/AggregatorV3Interface.sol";
 
 contract BnbOracle is Initializable {
 

--- a/contracts/oracle/BnbOracle.sol
+++ b/contracts/oracle/BnbOracle.sol
@@ -3,10 +3,15 @@ pragma solidity ^0.8.10;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { IResilientOracle } from "./interfaces/IResilientOracle.sol";
 
 contract BnbOracle is Initializable {
 
     AggregatorV3Interface internal priceFeed;
+    // @dev resilient oracle address
+    address constant public resilientOracleAddr = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+    // @dev *WBNB* token address
+    address constant public TOKEN = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
 
     function initialize(address aggregatorAddress) external initializer {
         priceFeed = AggregatorV3Interface(aggregatorAddress);
@@ -16,19 +21,9 @@ contract BnbOracle is Initializable {
      * Returns the latest price
      */
     function peek() public view returns (bytes32, bool) {
-        (
-            /*uint80 roundID*/,
-            int price,
-            /*uint startedAt*/,
-            uint timeStamp,
-            /*uint80 answeredInRound*/
-        ) = priceFeed.latestRoundData();
-        
-        require(block.timestamp - timeStamp < 300, "BnbOracle/timestamp-too-old");
-        
-        if (price < 0) {
-            return (0, false);
-        }
+        // get BNB price from resilient oracle, 8 decimals
+        // in case price is zero, resilient oracle will revert
+        uint256 price = IResilientOracle(resilientOracleAddr).peek(TOKEN);
         return (bytes32(uint(price) * (10**10)), true);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -37,13 +37,13 @@ const config: HardhatUserConfig = {
       },
     },
     bsc: {
-      url: `https://bsc-dataseed.binance.org/`,
+      url: process.env.BSC_RPC || `https://bsc-dataseed.binance.org/`,
       chainId: 56,
       accounts: [`0x${process.env.DEPLOYER_PRIVATE_KEY}`]
     },
 
     bsc_testnet: {
-      url: `https://data-seed-prebsc-2-s3.binance.org:8545/`,
+      url: process.env.BSC_TESTNET_RPC || `https://data-seed-prebsc-2-s3.binance.org:8545/`,
       chainId: 97,
       accounts: [`0x${process.env.DEPLOYER_PRIVATE_KEY}`],
       gasPrice: 15000000000 // 15 gwei
@@ -75,6 +75,11 @@ const config: HardhatUserConfig = {
     typechain: {
         outDir: 'typechain',
     },
+
+    sourcify: {
+        enabled: true
+    }
+
 };
 
 export default config;


### PR DESCRIPTION
BNB Oracle will be upgraded with a minor change. Before the upgrade it queries the BNB prices from a single oracle source which is ChainLink. After the upgrade, it will query price from the resilient oracle which is more robust and this can avoid single point of failure.

Proxy: 0xf81748d12171De989A5Bbf2d76bf10BFbBaEC596
current implementation: 0x097c2c40a0deff531832a7fdbf1bbb0aa3315bc2