### PR TITLE
fix: update duty on AMO param changes

### DIFF
--- a/contracts/amo/DynamicDutyCalculator.sol
+++ b/contracts/amo/DynamicDutyCalculator.sol
@@ -9,6 +9,8 @@ import "../interfaces/JugLike.sol";
 import "../libraries/FixedMath0x.sol";
 import "../oracle/interfaces/IResilientOracle.sol";
 
+import {IDao} from "../ceros/interfaces/IDao.sol";
+
 /**
     * @title DynamicDutyCalculator
     * @author Lista
@@ -109,6 +111,15 @@ contract DynamicDutyCalculator is IDynamicDutyCalculator, Initializable, AccessC
         ilks[collateral].beta = beta;
         ilks[collateral].rate0 = rate0;
         ilks[collateral].enabled = enabled;
+
+        uint256 price = oracle.peek(lisUSD);
+        ilks[collateral].lastPrice = price;
+
+        uint256 duty = calculateRate(price, beta, rate0) + 1e27;
+        if (duty > maxDuty) duty = maxDuty;
+        if (duty < minDuty) duty = minDuty;
+
+        IDao(interaction).setCollateralDuty(collateral, duty);
 
         emit CollateralParamsUpdated(collateral, beta, rate0, enabled);
     }

--- a/scripts/prod/amo/deploy_dutyCalculator_impl.ts
+++ b/scripts/prod/amo/deploy_dutyCalculator_impl.ts
@@ -1,0 +1,21 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const DynamicDutyCalculator = await ethers.getContractFactory(
+    "DynamicDutyCalculator"
+  );
+  const dutyCalculator = await DynamicDutyCalculator.deploy();
+  await dutyCalculator.waitForDeployment();
+  const dutyCalculatorAddress = await dutyCalculator.getAddress();
+  console.log(
+    "DynamicDutyCalculator impl contract deployed at: ",
+    dutyCalculatorAddress
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Currently when AMO params updated the duty will not change immediately since it's triggered by the lisUSD price fluctuations. We optimized the logic to have the duty updated upon params changes.

<img width="790" alt="image" src="https://github.com/user-attachments/assets/2b106d62-68ac-4f97-8ff3-57f2d39fdf36">

