### PR TITLE
chore: add node_modules to foundry.toml libs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,19 +1,11 @@
 [profile.default]
 src = 'contracts'
 out = 'out'
-libs = ['lib']
+libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'cache_forge'
 solc = "0.8.10"
 optimizer_runs = 200
-
-remappings=[
-    "@openzeppelin/contracts=./node_modules/@openzeppelin/contracts",
-    "@openzeppelin/contracts-upgradeable=./node_modules/@openzeppelin/contracts-upgradeable",
-    "hardhat=./node_modules/hardhat",
-    "@chainlink/contracts=./node_modules/@chainlink/contracts",
-    "@pythnetwork/pyth-sdk-solidity=./node_modules/@pythnetwork/pyth-sdk-solidity",
-]
 
 [rpc_endpoints]
 bsc-test = "https://bsc-testnet.bnbchain.org"


### PR DESCRIPTION
To fix the CI errors that cannot find `openzeppelin/contracts-upgradeable`files