### PR TITLE
+ refine lisUSD access management

### DIFF
--- a/contracts/LisUSD.sol
+++ b/contracts/LisUSD.sol
@@ -77,7 +77,8 @@ contract LisUSD is Initializable, IERC20MetadataUpgradeable {
     // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
     bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
-    address public constant DEFAULT_ADMIN = 0xAca0ed4651ddA1F43f00363643CFa5EBF8774b37;
+    // default admin is TimeLock contract
+    address public constant DEFAULT_ADMIN = 0x07D274a68393E8b8a2CCf19A2ce4Ba3518735253;
 
     function initialize(uint256 chainId_, string memory symbol_, uint256 supplyCap_) external initializer {
         wards[msg.sender] = 1;

--- a/contracts/old/LisUSDOld.sol
+++ b/contracts/old/LisUSDOld.sol
@@ -26,34 +26,13 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20Metadat
 // It doesn't use LibNote anymore.
 // New deployments of this contract will need to include custom events (TO DO).
 
-contract LisUSD is Initializable, IERC20MetadataUpgradeable {
-    enum Role {
-        NONE, // 0
-        MINTER, // 1
-        MANAGER, // 2
-        ADMIN // 3
-    }
-
+contract LisUSDOld is Initializable, IERC20MetadataUpgradeable {
     // --- Auth ---
     mapping (address => uint) public wards;
-    function rely(address guy, uint role) external onlyAdmin {
-        require(role > 0 && role <= uint(type(Role).max), "LisUSD/invalid-role");
-        wards[guy] = role;
-    }
-    function deny(address guy) external onlyAdmin { wards[guy] = 0; }
-
-    modifier onlyMinter() {
-        require(wards[msg.sender] == uint(Role.MINTER), "LisUSD/not-authorized-minter");
-        _;
-    }
-
-    modifier onlyManager() {
-        require(wards[msg.sender] == uint(Role.MANAGER), "LisUSD/not-authorized-manager");
-        _;
-    }
-
-    modifier onlyAdmin() {
-        require(wards[msg.sender] == uint(Role.ADMIN) || msg.sender == DEFAULT_ADMIN, "LisUSD/not-authorized-admin");
+    function rely(address guy) external auth { wards[guy] = 1; }
+    function deny(address guy) external auth { wards[guy] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "LisUSD/not-authorized");
         _;
     }
 
@@ -77,8 +56,6 @@ contract LisUSD is Initializable, IERC20MetadataUpgradeable {
     // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
     bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
 
-    address public constant DEFAULT_ADMIN = 0xAca0ed4651ddA1F43f00363643CFa5EBF8774b37;
-
     function initialize(uint256 chainId_, string memory symbol_, uint256 supplyCap_) external initializer {
         wards[msg.sender] = 1;
         DOMAIN_SEPARATOR = keccak256(abi.encode(
@@ -90,6 +67,11 @@ contract LisUSD is Initializable, IERC20MetadataUpgradeable {
         ));
         symbol = symbol_;
         supplyCap = supplyCap_;
+    }
+
+    function resetSymbol() external auth {
+        require(keccak256(abi.encodePacked(symbol)) != keccak256(abi.encodePacked("lisUSD")), "LisUSD/symbol-already-reset");
+        symbol = "lisUSD";
     }
 
     // --- Token ---
@@ -109,7 +91,7 @@ contract LisUSD is Initializable, IERC20MetadataUpgradeable {
         emit Transfer(src, dst, wad);
         return true;
     }
-    function mint(address usr, uint wad) external onlyMinter {
+    function mint(address usr, uint wad) external auth {
         require(usr != address(0), "LisUSD/mint-to-zero-address");
         require(totalSupply + wad <= supplyCap, "LisUSD/cap-reached");
         balanceOf[usr] += wad;
@@ -147,19 +129,19 @@ contract LisUSD is Initializable, IERC20MetadataUpgradeable {
 
     // --- Approve by signature ---
     function permit(address holder, address spender, uint256 nonce, uint256 expiry,
-                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
+        bool allowed, uint8 v, bytes32 r, bytes32 s) external
     {
         bytes32 digest =
-            keccak256(abi.encodePacked(
+                        keccak256(abi.encodePacked(
                 "\x19\x01",
                 DOMAIN_SEPARATOR,
                 keccak256(abi.encode(PERMIT_TYPEHASH,
-                                     holder,
-                                     spender,
-                                     nonce,
-                                     expiry,
-                                     allowed))
-        ));
+                    holder,
+                    spender,
+                    nonce,
+                    expiry,
+                    allowed))
+            ));
 
         require(holder != address(0), "LisUSD/invalid-address-0");
         require(holder == ecrecover(digest, v, r, s), "LisUSD/invalid-permit");
@@ -198,14 +180,14 @@ contract LisUSD is Initializable, IERC20MetadataUpgradeable {
         return true;
     }
 
-    function setSupplyCap(uint256 wad) public onlyManager {
+    function setSupplyCap(uint256 wad) public auth {
         require(wad >= totalSupply, "LisUSD/more-supply-than-cap");
         uint256 oldCap = supplyCap;
         supplyCap = wad;
         emit SupplyCapSet(oldCap, supplyCap);
     }
 
-    function updateDomainSeparator(uint256 chainId_) external onlyManager {
+    function updateDomainSeparator(uint256 chainId_) external auth {
         DOMAIN_SEPARATOR = keccak256(abi.encode(
             keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
             keccak256(bytes(name)),

--- a/test/foundry/LisUSDAcl.t.sol
+++ b/test/foundry/LisUSDAcl.t.sol
@@ -53,7 +53,6 @@ contract LisUSDAclTest is Test {
         vm.stopPrank();
 
         lisUSD = LisUSD(0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5);
-
     }
 
     function test_setUp() public {

--- a/test/foundry/LisUSDAcl.t.sol
+++ b/test/foundry/LisUSDAcl.t.sol
@@ -1,0 +1,165 @@
+pragma solidity ^0.8.10;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import "../../contracts/LisUSD.sol";
+import "../../contracts/old/LisUSDOld.sol";
+
+
+contract LisUSDAclTest is Test {
+    address user0 = address(0x0A11AA);
+    address user1 = address(0x1A11AA);
+
+    address newAdmin0 = address(0x2A11AA);
+    address newAdmin1 = address(0x3A11AA);
+
+    address manager0 = address(0x4A11AA);
+    address manager1 = address(0x5A11AA);
+
+    address sender;
+
+    uint256 mainnet;
+
+    LisUSDOld oldLisUSD;
+
+    LisUSD lisUSD;
+
+    function setUp() public {
+        mainnet = vm.createSelectFork("https://bsc-dataseed.binance.org");
+        oldLisUSD = LisUSDOld(0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5);
+
+        vm.startPrank(0xAca0ed4651ddA1F43f00363643CFa5EBF8774b37);
+        oldLisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+
+        assertEq(100 ether, oldLisUSD.balanceOf(user0));
+
+        // HayJoin
+        vm.startPrank(0x4C798F81de7736620Cd8e6510158b1fE758e22F7);
+        oldLisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+
+        assertEq(200 ether, oldLisUSD.balanceOf(user0));
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(address(0x1Fa3E4718168077975fF4039304CC2e19Ae58c4C));
+        vm.startPrank(address(proxyAdmin.owner()));
+        LisUSD newLisUSD = new LisUSD();
+        ITransparentUpgradeableProxy proxy = ITransparentUpgradeableProxy(address(0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5));
+        proxyAdmin.upgrade(proxy, address(newLisUSD));
+        vm.stopPrank();
+
+        lisUSD = LisUSD(0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5);
+
+    }
+
+    function test_setUp() public {
+        deal(address(lisUSD), user0, 0);
+
+        vm.startPrank(0xAca0ed4651ddA1F43f00363643CFa5EBF8774b37);
+        lisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+
+        assertEq(100 ether, lisUSD.balanceOf(user0));
+
+        // HayJoin
+        vm.startPrank(0x4C798F81de7736620Cd8e6510158b1fE758e22F7);
+        lisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+
+        assertEq(200 ether, lisUSD.balanceOf(user0));
+    }
+
+    function test_rely_minter() public {
+        vm.startPrank(lisUSD.DEFAULT_ADMIN());
+        lisUSD.rely(newAdmin0, 1);
+        vm.stopPrank();
+
+        assertEq(1, lisUSD.wards(newAdmin0));
+
+        vm.startPrank(newAdmin0);
+        lisUSD.mint(user1, 100 ether);
+        vm.stopPrank();
+        assertEq(100 ether, lisUSD.balanceOf(user1));
+
+        // HayJoin
+        vm.startPrank(0x4C798F81de7736620Cd8e6510158b1fE758e22F7);
+        vm.expectRevert("LisUSD/not-authorized-admin");
+        lisUSD.rely(newAdmin1, 1);
+        vm.stopPrank();
+    }
+
+    function test_deny_minter() public {
+        test_rely_minter();
+
+        vm.startPrank(0x4C798F81de7736620Cd8e6510158b1fE758e22F7);
+        vm.expectRevert("LisUSD/not-authorized-admin");
+        lisUSD.deny(newAdmin0);
+        vm.stopPrank();
+        assertEq(1, lisUSD.wards(newAdmin0));
+
+        vm.startPrank(lisUSD.DEFAULT_ADMIN());
+        lisUSD.deny(newAdmin0);
+        vm.stopPrank();
+        assertEq(0, lisUSD.wards(newAdmin0));
+
+        // unable to mint
+        vm.startPrank(newAdmin0);
+        vm.expectRevert("LisUSD/not-authorized-minter");
+        lisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+    }
+
+    function test_rely_manager() public {
+        vm.startPrank(manager0);
+        vm.expectRevert("LisUSD/not-authorized-manager");
+        lisUSD.setSupplyCap(80_000_000 ether);
+        vm.stopPrank();
+
+        vm.startPrank(lisUSD.DEFAULT_ADMIN());
+        lisUSD.rely(manager0, 2);
+        vm.stopPrank();
+
+        vm.startPrank(manager0);
+        lisUSD.setSupplyCap(80_000_000 ether);
+        vm.stopPrank();
+        assertEq(80_000_000 ether, lisUSD.supplyCap());
+
+        // unable to mint
+        vm.startPrank(manager0);
+        vm.expectRevert("LisUSD/not-authorized-minter");
+        lisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+    }
+
+    function test_rely_admin() public {
+        vm.startPrank(newAdmin1);
+        vm.expectRevert("LisUSD/not-authorized-admin");
+        lisUSD.rely(address(1), 3);
+        vm.stopPrank();
+
+        vm.startPrank(lisUSD.DEFAULT_ADMIN());
+        lisUSD.rely(newAdmin1, 3);
+        vm.stopPrank();
+        assertEq(3, lisUSD.wards(newAdmin1));
+
+        // unable to mint
+        vm.startPrank(newAdmin1);
+        vm.expectRevert("LisUSD/not-authorized-minter");
+        lisUSD.mint(user0, 100 ether);
+        vm.stopPrank();
+
+        vm.startPrank(newAdmin1);
+        lisUSD.rely(address(1), 3);
+        vm.stopPrank();
+        assertEq(3, lisUSD.wards(address(1)));
+
+        vm.startPrank(address(1));
+        lisUSD.rely(address(2), 3);
+        vm.stopPrank();
+        assertEq(3, lisUSD.wards(address(2)));
+    }
+}


### PR DESCRIPTION
Refine the access control of lisUSD, separate the admin role and the manager role from the minter role