### PR TITLE
Fix: withdraw historic leftover slisBnb

### DIFF
--- a/contracts/ceros/interfaces/IDao.sol
+++ b/contracts/ceros/interfaces/IDao.sol
@@ -40,4 +40,6 @@ interface IDao {
     function collaterals(address token) external view returns (GemJoinLike, bytes32, uint32, address);
 
     function locked(address token, address usr) external view returns (uint256);
+
+    function free(address token, address usr) external view returns (uint256);
 }

--- a/contracts/ceros/mocks/Dao.sol
+++ b/contracts/ceros/mocks/Dao.sol
@@ -42,4 +42,7 @@ contract Dao is IDao {
     return 0;
   }
 
+  function free(address token, address usr) public view returns (uint256) {
+    return 0;
+  }
 }

--- a/contracts/ceros/provider/SlisBNBProvider.sol
+++ b/contracts/ceros/provider/SlisBNBProvider.sol
@@ -159,6 +159,15 @@ contract SlisBNBProvider is BaseTokenProvider {
     }
 
     /**
+     * @dev withdraw leftover collateral from Interaction contract; to support historical liquidated slisBnb urns
+     * @param _amount token amount to withdraw
+     */
+    function withdrawLeftover(uint256 _amount) external {
+        require(dao.free(token, msg.sender) >= _amount, "not enough leftover");
+        dao.withdraw(msg.sender, token, _amount);
+    }
+
+    /**
      * check if user lp token is synced with token balance
      *
      * @param _account lp token owner

--- a/contracts/ceros/provider/SlisBNBProvider.sol
+++ b/contracts/ceros/provider/SlisBNBProvider.sol
@@ -161,10 +161,12 @@ contract SlisBNBProvider is BaseTokenProvider {
     /**
      * @dev withdraw leftover collateral from Interaction contract; to support historical liquidated slisBnb urns
      */
-    function withdrawLeftover() external {
+    function withdrawLeftover() external whenNotPaused nonReentrant {
         uint256 leftover = dao.free(token, msg.sender);
         require(leftover > 0, "no leftover");
-        dao.withdraw(msg.sender, token, leftover);
+        uint256 amount = dao.withdraw(msg.sender, token, leftover);
+
+        IERC20(token).safeTransfer(msg.sender, amount);
     }
 
     /**

--- a/contracts/ceros/provider/SlisBNBProvider.sol
+++ b/contracts/ceros/provider/SlisBNBProvider.sol
@@ -160,11 +160,11 @@ contract SlisBNBProvider is BaseTokenProvider {
 
     /**
      * @dev withdraw leftover collateral from Interaction contract; to support historical liquidated slisBnb urns
-     * @param _amount token amount to withdraw
      */
-    function withdrawLeftover(uint256 _amount) external {
-        require(dao.free(token, msg.sender) >= _amount, "not enough leftover");
-        dao.withdraw(msg.sender, token, _amount);
+    function withdrawLeftover() external {
+        uint256 leftover = dao.free(token, msg.sender);
+        require(leftover > 0, "no leftover");
+        dao.withdraw(msg.sender, token, leftover);
     }
 
     /**

--- a/scripts/deploy/ceros/deploy_slisBnbProvider_impl.ts
+++ b/scripts/deploy/ceros/deploy_slisBnbProvider_impl.ts
@@ -1,0 +1,23 @@
+const hre = require("hardhat");
+const {ethers} = hre;
+
+async function main() {
+  const SlisBNBProvider = await ethers.getContractFactory('SlisBNBProvider');
+  const _provider = await SlisBNBProvider.deploy();
+  await _provider.waitForDeployment();
+  const _providerAddress = await _provider.getAddress();
+  console.log('contract deployed at: ', _providerAddress);
+  // waiting for ~5 blocks, in case scan doesn't sync in time
+  await new Promise((resolve) => setTimeout(resolve, 3000 * 5));
+  console.log('---------- verifying contract ----------')
+  await hre.run("verify:verify", {
+    address: _providerAddress,
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/foundry/ceros/provider/SlisBNBProvider.t.sol
+++ b/test/foundry/ceros/provider/SlisBNBProvider.t.sol
@@ -647,4 +647,24 @@ contract SlisBNBProviderTest is Test {
         assertEq(0, clisBnb.balanceOf(reserveAddress));
         assertEq(0, slisBNBLpProvider.userReservedLp(user));
     }
+
+    function test_withdrawLeftover() external {
+        address usr_A = 0xa0e7f96D7E9Cb3E150139343404C2b9a3ff1D1e6;
+        uint256 leftover = interaction.free(address(slisBnb), usr_A);
+        uint256 locked = interaction.locked(address(slisBnb), usr_A);
+
+        vm.expectRevert("not enough leftover");
+        vm.startPrank(usr_A);
+        slisBNBLpProvider.withdrawLeftover(leftover + 1 ether);
+
+        slisBNBLpProvider.withdrawLeftover(leftover - 1000);
+        leftover = interaction.free(address(slisBnb), usr_A);
+        assertEq(leftover, 1000);
+        assertEq(locked, interaction.locked(address(slisBnb), usr_A));
+
+        slisBNBLpProvider.withdrawLeftover(leftover);
+        leftover = interaction.free(address(slisBnb), usr_A);
+        assertEq(leftover, 0);
+        assertEq(locked, interaction.locked(address(slisBnb), usr_A));
+    }
 }

--- a/test/foundry/ceros/provider/SlisBNBProvider.t.sol
+++ b/test/foundry/ceros/provider/SlisBNBProvider.t.sol
@@ -653,16 +653,8 @@ contract SlisBNBProviderTest is Test {
         uint256 leftover = interaction.free(address(slisBnb), usr_A);
         uint256 locked = interaction.locked(address(slisBnb), usr_A);
 
-        vm.expectRevert("not enough leftover");
         vm.startPrank(usr_A);
-        slisBNBLpProvider.withdrawLeftover(leftover + 1 ether);
-
-        slisBNBLpProvider.withdrawLeftover(leftover - 1000);
-        leftover = interaction.free(address(slisBnb), usr_A);
-        assertEq(leftover, 1000);
-        assertEq(locked, interaction.locked(address(slisBnb), usr_A));
-
-        slisBNBLpProvider.withdrawLeftover(leftover);
+        slisBNBLpProvider.withdrawLeftover();
         leftover = interaction.free(address(slisBnb), usr_A);
         assertEq(leftover, 0);
         assertEq(locked, interaction.locked(address(slisBnb), usr_A));

--- a/test/foundry/ceros/provider/SlisBNBProvider.t.sol
+++ b/test/foundry/ceros/provider/SlisBNBProvider.t.sol
@@ -654,7 +654,9 @@ contract SlisBNBProviderTest is Test {
         uint256 locked = interaction.locked(address(slisBnb), usr_A);
 
         vm.startPrank(usr_A);
+        uint256 balance = slisBnb.balanceOf(usr_A);
         slisBNBLpProvider.withdrawLeftover();
+        assertEq(balance + leftover, slisBnb.balanceOf(usr_A));
         leftover = interaction.free(address(slisBnb), usr_A);
         assertEq(leftover, 0);
         assertEq(locked, interaction.locked(address(slisBnb), usr_A));


### PR DESCRIPTION
Add `withdrawLeftover` method to enable users to withdraw historical liquidated slisBnb leftovers.