### PR TITLE
+ Feature/slisBNB Price Feed

### DIFF
--- a/contracts/oracle/SlisBnbOracle.sol
+++ b/contracts/oracle/SlisBnbOracle.sol
@@ -3,30 +3,20 @@ pragma solidity ^0.8.10;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { ISnBnbStakeManager } from "../snbnb/interfaces/ISnBnbStakeManager.sol";
 import { IResilientOracle } from "./interfaces/IResilientOracle.sol";
 
 contract SlisBnbOracle is Initializable {
 
-  AggregatorV3Interface internal priceFeed;
-  // @dev Stake Manager Address
-  address internal constant stakeManagerAddr = 0x1adB950d8bB3dA4bE104211D5AB038628e477fE6;
   // @dev resilient oracle address
-  address constant public resilientOracleAddr = 0xf3afD82A4071f272F403dC176916141f44E6c750;
-  // @dev *WBNB* token address
-  address constant public TOKEN = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
-
-  function initialize(address aggregatorAddress) external initializer {
-    priceFeed = AggregatorV3Interface(aggregatorAddress);
-  }
+  address constant public RESILIENT_ORACLE_ADDR = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+  // @dev slisBNB token address
+  address constant public SLISBNB_TOKEN_ADDR = 0xB0b84D294e0C75A6abe60171b70edEb2EFd14A1B;
 
   /**
-   * Returns the latest price
+   * Get the latest price of slisBNB
    */
   function peek() public view returns (bytes32, bool) {
-    // get BNB price from resilient oracle, 8 decimals
-    // in case price is zero, resilient oracle will revert
-    uint256 price = IResilientOracle(resilientOracleAddr).peek(TOKEN);
-    return (bytes32(uint(price) * ISnBnbStakeManager(stakeManagerAddr).convertSnBnbToBnb(10**10)), true);
+    uint256 price = IResilientOracle(RESILIENT_ORACLE_ADDR).peek(SLISBNB_TOKEN_ADDR);
+    return (bytes32(uint(price) * 1e10), true);
   }
 }

--- a/contracts/oracle/priceFeeds/SlisBnbPriceFeed.sol
+++ b/contracts/oracle/priceFeeds/SlisBnbPriceFeed.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "../interfaces/IResilientOracle.sol";
+import { ISnBnbStakeManager } from "../../snbnb/interfaces/ISnBnbStakeManager.sol";
+
+/**
+  * @title slisBnbPriceFeed
+  * @dev The contract obtains WBNB price from the Resilient Oracle and converts it to slisBNB using the SnBnbStakeManager.
+  */
+contract SlisBnbPriceFeed {
+
+  IResilientOracle public resilientOracle;
+  ISnBnbStakeManager public stakeManager;
+
+  address public constant WBNB_TOKEN_ADDR = 0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c;
+
+  constructor(address _resilientOracle, address _stakeManager) {
+    require(_resilientOracle != address(0) && _stakeManager != address (0), "Zero address provided");
+    resilientOracle = IResilientOracle(_resilientOracle);
+    stakeManager = ISnBnbStakeManager(_stakeManager);
+  }
+
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  function description() external pure returns (string memory) {
+    return "slisBNB Price Feed";
+  }
+
+  function version() external pure returns (uint256) {
+    return 1;
+  }
+
+  function latestAnswer() external view returns (int256 answer) {
+    // get price
+    uint256 price = getPrice();
+    // cast price to int256
+    answer = int256(price);
+  }
+
+  function latestRoundData()
+  external
+  view
+  returns (
+    uint80 roundId,
+    int256 answer,
+    uint256 startedAt,
+    uint256 updatedAt,
+    uint80 answeredInRound
+  ) {
+    // get price
+    uint256 _answer = getPrice();
+    // mock timestamp to latest block timestamp
+    uint256 timestamp = block.timestamp;
+    // mock roundId to timestamp
+    roundId = uint80(timestamp);
+    return (
+      roundId,
+      int256(_answer),
+      timestamp,
+      timestamp,
+      roundId
+    );
+  }
+
+  /**
+    * @dev Get the WBNB price from the Resilient Oracle, and
+    * @return price The price of slisBNB in 8 decimals
+    */
+  function getPrice() private view returns (uint256 price) {
+    // get BNB price from resilient oracle (8 Decimal place)
+    // in case price is zero, resilient oracle will revert
+    price = resilientOracle.peek(WBNB_TOKEN_ADDR);
+    price = stakeManager.convertSnBnbToBnb(price);
+  }
+
+}

--- a/scripts/prod/priceFeed/deploy_slisbnb_price_feed.js
+++ b/scripts/prod/priceFeed/deploy_slisbnb_price_feed.js
@@ -1,0 +1,24 @@
+const {ethers, upgrades} = require('hardhat')
+const hre = require('hardhat')
+
+const RESILIENT_ORACLE = "0xf3afD82A4071f272F403dC176916141f44E6c750"
+const STAKE_MANAGER = "0x1adB950d8bB3dA4bE104211D5AB038628e477fE6"
+
+async function main() {
+  console.log(`[slisBNB Price Feed] Deploying...`)
+  const factory = await ethers.getContractFactory('SlisBnbPriceFeed');
+  const contract = await factory.deploy(RESILIENT_ORACLE, STAKE_MANAGER);
+  await contract.deploymentTransaction().wait(6);
+  const address = await contract.getAddress();
+  console.log('[slisBNB Price Feed] Deployed to:', address);
+
+  console.log(`[slisBNB Price Feed] Verifying...`)
+  await hre.run("verify:verify", {address, constructorArguments: [RESILIENT_ORACLE, STAKE_MANAGER]});
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })


### PR DESCRIPTION
1. Added slisBNB Price Feed contract - Fetch WBNB's price from the resilient oracle and the conversion rate of slisBNB > BNB, then get slisBNB's price by multiplying them together.

2. Amended slisBNB Oracle - after the above price feed is configured to the resilient oracle, fetch price from it directly.