### PR TITLE
fea: add lisUSD fixed price feed

### DIFF
--- a/contracts/oracle/priceFeeds/lisUSDPriceFeed.sol
+++ b/contracts/oracle/priceFeeds/lisUSDPriceFeed.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+/**
+  * @title lisUSDPriceFeed
+  * @dev Fixed-price feed that returns 1 USD (1e8) for lisUSD,
+  *      compatible with Chainlink AggregatorV3Interface.
+  */
+contract lisUSDPriceFeed {
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  function description() external pure returns (string memory) {
+    return "lisUSD Price Feed";
+  }
+
+  function version() external pure returns (uint256) {
+    return 1;
+  }
+
+  /**
+    * @dev Returns the latest lisUSD price in 8 decimals
+    * @return answer The price of lisUSD in USD (always 1e8)
+    */
+  function latestAnswer() external pure returns (int256 answer) {
+    answer = int256(getPrice());
+  }
+
+  /**
+    * @dev Returns Chainlink-compatible round data with mocked fields
+    * @return roundId Mocked as current block timestamp
+    * @return answer The price of lisUSD in USD (always 1e8)
+    * @return startedAt Current block timestamp
+    * @return updatedAt Current block timestamp
+    * @return answeredInRound Same as roundId
+    */
+  function latestRoundData()
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    )
+  {
+    uint256 _answer = getPrice();
+    uint256 timestamp = block.timestamp;
+    roundId = uint80(timestamp);
+    return (
+      roundId,
+      int256(_answer),
+      timestamp,
+      timestamp,
+      roundId
+    );
+  }
+
+  function getPrice() private pure returns (uint256 price) {
+    return 1e8;
+  }
+}

--- a/scripts/prod/oracle/priceFeed/deploy_lisUSD_price_feed.sol
+++ b/scripts/prod/oracle/priceFeed/deploy_lisUSD_price_feed.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Script.sol";
+
+import { lisUSDPriceFeed } from "../../../../contracts/oracle/priceFeeds/lisUSDPriceFeed.sol";
+
+contract lisUSDPriceFeedDeploy is Script {
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        console.log("Deployer: ", deployer);
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Deploy lisUSD price feed
+        lisUSDPriceFeed feed = new lisUSDPriceFeed();
+        console.log("feed deployed to: ", address(feed));
+
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `lisUSDPriceFeed` contract that returns a fixed price of 1 USD (1e8), compatible with Chainlink AggregatorV3Interface
- Add Foundry deployment script

## Test plan
- [x] Contract compiles successfully
- [ ] Deploy to testnet and verify `latestAnswer()` returns `1e8`
- [ ] Verify `latestRoundData()` returns correct mocked fields