### PR TITLE
fea: add syrupUSDT price feed

### DIFF
--- a/contracts/oracle/priceFeeds/SyrupUSDTPriceFeed.sol
+++ b/contracts/oracle/priceFeeds/SyrupUSDTPriceFeed.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "../interfaces/IResilientOracle.sol";
+import "../interfaces/AggregatorV3Interface.sol";
+import "../libraries/FullMath.sol";
+
+/**
+  * @title SyrupUSDTPriceFeed
+  * @dev Contract provides syrupUSDT/USD in 8 DPs
+  */
+contract SyrupUSDTPriceFeed {
+
+  IResilientOracle public resilientOracle;
+  AggregatorV3Interface public syrupUSDT_USDT_PriceFeed;
+  address public constant USDT_TOKEN_ADDR = 0x55d398326f99059fF775485246999027B3197955;
+
+  /**
+    * @dev Constructor
+    * @param _resilientOracle The address of the Resilient Oracle contract
+    * @param _syrupUSDT_USDT_PriceFeed The address of the syrupUSDT/USDT exchange rate price feed contract (ChainLink)
+    */
+  constructor(address _resilientOracle, address _syrupUSDT_USDT_PriceFeed) {
+    require(_resilientOracle != address(0) && _syrupUSDT_USDT_PriceFeed != address(0), "Zero address provided");
+    resilientOracle = IResilientOracle(_resilientOracle);
+    syrupUSDT_USDT_PriceFeed = AggregatorV3Interface(_syrupUSDT_USDT_PriceFeed);
+  }
+
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  function description() external pure returns (string memory) {
+    return "syrupUSDT/USD Price Feed";
+  }
+
+  function version() external pure returns (uint256) {
+    return 1;
+  }
+
+  function latestAnswer() external view returns (int256 answer) {
+    // get price
+    uint256 price = getPrice();
+    // cast price to int256
+    answer = int256(price);
+  }
+
+  function latestRoundData()
+  external
+  view
+  returns (
+    uint80 roundId,
+    int256 answer,
+    uint256 startedAt,
+    uint256 updatedAt,
+    uint80 answeredInRound
+  ) {
+    // get price
+    uint256 _answer = getPrice();
+    // mock timestamp to latest block timestamp
+    uint256 timestamp = block.timestamp;
+    // mock roundId to timestamp
+    roundId = uint80(timestamp);
+    return (
+      roundId,
+      int256(_answer),
+      timestamp,
+      timestamp,
+      roundId
+    );
+  }
+
+  /**
+    * @dev Get the price of syrupUSDT/USD in 8 DPs
+    *      syrupUSDT/USDT from ChainLink exchange rate feed and USDT/USD from Resilient Oracle
+    *      multiply them and divide by 1e18
+    * @return price The price of syrupUSDT/USD in 8 decimals
+    */
+  function getPrice() private view returns (uint256 price) {
+    // (1) syrupUSDT/USDT exchange rate in 18 DPs
+    (
+    /*uint80 roundID*/,
+      int syrupUSDT_USDT_Price,
+    /*uint startedAt*/,
+      uint updatedAt1,
+    /*uint80 answeredInRound*/
+    ) = syrupUSDT_USDT_PriceFeed.latestRoundData();
+
+    require(syrupUSDT_USDT_Price > 0, "syrupUSDT_USDT_PriceFeed/price-not-valid");
+    require(block.timestamp - updatedAt1 < (24 * 3600 + 300), "syrupUSDT_USDT_PriceFeed/timestamp-too-old");
+
+    // (2) USDT/USD in 8 DPs
+    uint256 USDT_Usd_Price = resilientOracle.peek(USDT_TOKEN_ADDR);
+
+    return FullMath.mulDiv(uint256(syrupUSDT_USDT_Price), USDT_Usd_Price, 1e18);
+  }
+
+}

--- a/scripts/prod/priceFeed/deploy_syrupUSDT_price_feed.sol
+++ b/scripts/prod/priceFeed/deploy_syrupUSDT_price_feed.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import "forge-std/Script.sol";
+
+import { SyrupUSDTPriceFeed } from "../../../contracts/oracle/priceFeeds/SyrupUSDTPriceFeed.sol";
+
+contract SyrupUSDTPriceFeedTest is Script {
+    address resilientOracle = 0xf3afD82A4071f272F403dC176916141f44E6c750;
+    address syrupUSDT_USDT_PriceFeed = 0xac9962aAb7b8fe63fA3A5065c22D4Dd700B1C658;
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        console.log("Deployer: ", deployer);
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Deploy Interaction SyrupUSDTPriceFeed
+        SyrupUSDTPriceFeed feed = new SyrupUSDTPriceFeed(resilientOracle, syrupUSDT_USDT_PriceFeed);
+        console.log("feed deployed to: ", address(feed));
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/foundry/oracle/PriceFeed.t.sol
+++ b/test/foundry/oracle/PriceFeed.t.sol
@@ -8,6 +8,7 @@ import "../../../contracts/oracle/priceFeeds/USDXLiquidationPriceFeed.sol";
 import "../../../contracts/oracle/priceFeeds/mXRPPriceFeed.sol";
 import "../../../contracts/oracle/priceFeeds/sUSD1PriceFeed.sol";
 import "../../../contracts/oracle/priceFeeds/sUSDXLiquidationPriceFeed.sol";
+import "../../../contracts/oracle/priceFeeds/SyrupUSDTPriceFeed.sol";
 import "../../../contracts/oracle/priceFeeds/uniBTCPriceFeed.sol";
 import "../../../contracts/oracle/priceFeeds/wNLPUSDTPriceFeed.sol";
 import "../../../contracts/oracle/priceFeeds/wsrUSDPriceFeed.sol";
@@ -133,5 +134,16 @@ contract PriceFeedTest is Test {
         uint256 wNLP_USDT_Rate = wNLP.getNlpByWnlp(1e18);
 
         assertEq(int256(Math.mulDiv(usdtPrice, wNLP_USDT_Rate, 1e18)), answer);
+    }
+
+    function test_SyrupUSDTPriceFeed() public {
+        address syrupUSDT_USDT_PriceFeed = 0xac9962aAb7b8fe63fA3A5065c22D4Dd700B1C658;
+        SyrupUSDTPriceFeed feed = new SyrupUSDTPriceFeed(resilientOracle, syrupUSDT_USDT_PriceFeed);
+        (, int256 answer,,,) = feed.latestRoundData();
+
+        uint256 usdtPrice = IResilientOracle(resilientOracle).peek(feed.USDT_TOKEN_ADDR());
+        (, int256 syrupUSDT_USDT_Price,,,) = AggregatorV3Interface(syrupUSDT_USDT_PriceFeed).latestRoundData();
+
+        assertEq(int256(Math.mulDiv(uint256(syrupUSDT_USDT_Price), usdtPrice, 1e18)), answer);
     }
 }


### PR DESCRIPTION
## Summary

Add `SyrupUSDTPriceFeed`, a USD price feed for syrupUSDT that wraps the Chainlink syrupUSDT/USDT exchange-rate feed (`0xac9962aAb7b8fe63fA3A5065c22D4Dd700B1C658`) and multiplies it by USDT/USD from the Resilient Oracle, returning syrupUSDT/USD in 8 decimals. Mirrors the existing `sUSDePriceFeed` / `wsrUSDPriceFeed` / `sUSD1PriceFeed` pattern.

## Change type

- [x] New contract
- [ ] Upgrade (existing proxy)
- [ ] Bug fix
- [ ] Gas optimization
- [ ] Configuration change
- [x] Migration / deploy script
- [x] Test
- [ ] Dependency update

## Contracts changed

| Contract | File | Type |
|----------|------|------|
| `SyrupUSDTPriceFeed` | `contracts/oracle/priceFeeds/SyrupUSDTPriceFeed.sol` | new |
| `PriceFeedTest` | `test/foundry/oracle/PriceFeed.t.sol` | modified (added `test_SyrupUSDTPriceFeed`) |
| `SyrupUSDTPriceFeedTest` (deploy script) | `scripts/prod/priceFeed/deploy_syrupUSDT_price_feed.sol` | new |

## Interface changes

New external/public surface on `SyrupUSDTPriceFeed`:
- `constructor(address _resilientOracle, address _syrupUSDT_USDT_PriceFeed)` — zero-address checks on both inputs
- `resilientOracle()`, `syrupUSDT_USDT_PriceFeed()`, `USDT_TOKEN_ADDR()` (public state getters)
- `decimals() external pure returns (uint8)` → 8
- `description() external pure returns (string memory)` → `"syrupUSDT/USD Price Feed"`
- `version() external pure returns (uint256)` → 1
- `latestAnswer() external view returns (int256)` — Chainlink-compatible
- `latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80)` — Chainlink-compatible, mocks `roundId/timestamps` to `block.timestamp`

## Storage layout

N/A — not an upgradeable contract.

## Access control

Unchanged. Contract has no privileged functions; `resilientOracle` and `syrupUSDT_USDT_PriceFeed` are set once in the constructor and never mutated.

## Risk assessment

| Area | Risk | Note |
|------|------|------|
| Storage collision | 🟢 None | Stateless after construction; not behind a proxy |
| Fund safety | 🟢 None | No token transfers or external state mutations |
| Access control | 🟢 None | No privileged functions |
| External call safety | 🟡 Low | Reads from Chainlink feed + Resilient Oracle. Reverts if feed returns ≤ 0 or is older than 24h05m. Multiplication overflow protected by `FullMath.mulDiv` |

## Deployment

- Chain: BSC mainnet
- Script: `scripts/prod/priceFeed/deploy_syrupUSDT_price_feed.sol`
- Env vars: `PRIVATE_KEY` (deployer)
- Run: `forge script scripts/prod/priceFeed/deploy_syrupUSDT_price_feed.sol --rpc-url bsc --private-key $PK --broadcast --verify -vvv --via-ir`

## Test plan

- [x] `forge test --mt test_SyrupUSDTPriceFeed -vv` passes (fork test on BSC verifies `latestRoundData()` equals `mulDiv(rate, USDT/USD, 1e18)`)
- [ ] After deploy, confirm `feed.latestAnswer()` returns a reasonable value (~ syrupUSDT/USD; should be ≥ USDT/USD since exchange rate ≥ 1)
- [ ] Configure into ResilientOracle + BoundValidator (see runbook)